### PR TITLE
fix shellcheck warnings and fmt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,74 +17,73 @@
 #
 ##############################################################################
 
-echo && read -p 'Do you already have docker installed? [y/n] ' DOCKER
+echo && read -rp 'Do you already have docker installed? [y/n] ' DOCKER
 
 if [[ ($DOCKER = n) || ($DOCKER = no) ]]; then
-  echo -e '\nWe will install docker interactively before building the image.\n'
-  curl -fsSL 'https://raw.githubusercontent.com/phx/dockerinstall/master/install_docker.sh' | /bin/bash 
+	echo -e '\nWe will install docker interactively before building the image.\n'
+	curl -fsSL 'https://raw.githubusercontent.com/phx/dockerinstall/master/install_docker.sh' | /bin/bash
 fi
 
 # parse .env file if it exists
 if [[ -f .env ]]; then
-  values="$(awk -F '=' '{print $2}' .env)"
-  VPN_USER="$(echo "$values" | head -1)"
-  VPN_PASS="$(echo "$values" | awk 'NR==2')"
-  SECRET_KEY="$(echo "$values" | awk 'NR==3')"
-  VPN_ENDPOINT="$(echo "$values" | awk 'NR==4')"
-  PROXY_USER="$(echo "$values" | awk 'NR==5')"
-  PROXY_PASS="$(echo "$values" | awk 'NR==6')"
-  PROXY_HOST="$(echo "$values" | awk 'NR==7')"
-  PROXY_PORT="$(echo "$values" | awk 'NR==8')"
+	values="$(awk -F '=' '{print $2}' .env)"
+	VPN_USER="$(echo "$values" | head -1)"
+	VPN_PASS="$(echo "$values" | awk 'NR==2')"
+	SECRET_KEY="$(echo "$values" | awk 'NR==3')"
+	VPN_ENDPOINT="$(echo "$values" | awk 'NR==4')"
+	PROXY_USER="$(echo "$values" | awk 'NR==5')"
+	PROXY_PASS="$(echo "$values" | awk 'NR==6')"
+	PROXY_HOST="$(echo "$values" | awk 'NR==7')"
+	PROXY_PORT="$(echo "$values" | awk 'NR==8')"
 else
-  read -p 'Enter your VPN username: ' VPN_USER
-  read -p 'Enter your VPN password: ' VPN_PASS
-  read -p 'Enter your VPN secret key: ' SECRET_KEY
-  read -p 'Enter your VPN endpoint: ' VPN_ENDPOINT
-  read -p 'Enter your PROXY username: [none] ' PROXY_USER
-  read -p 'Enter your PROXY password: [none] ' PROXY_PASS
-  read -p 'Enter your upstream remote PROXY IP address: ' PROXY_HOST
-  read -p 'Enter your upstream remote PROXY port: ' PROXY_PORT
+	read -rp 'Enter your VPN username: ' VPN_USER
+	read -rp 'Enter your VPN password: ' VPN_PASS
+	read -rp 'Enter your VPN secret key: ' SECRET_KEY
+	read -rp 'Enter your VPN endpoint: ' VPN_ENDPOINT
+	read -rp 'Enter your PROXY username: [none] ' PROXY_USER
+	read -rp 'Enter your PROXY password: [none] ' PROXY_PASS
+	read -rp 'Enter your upstream remote PROXY IP address: ' PROXY_HOST
+	read -rp 'Enter your upstream remote PROXY port: ' PROXY_PORT
 fi
 
 # Remove 'sed -i' for MacOS native compatibility:
-sed "s/\[VPN_USER\]/$VPN_USER/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/\[VPN_PASS\]/$VPN_PASS/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/\[SECRET_KEY\]/$SECRET_KEY/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/\[PROXY_USER\]/$PROXY_USER/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/\[PROXY_PASS\]/$PROXY_PASS/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/\[PROXY_HOST\]/$PROXY_HOST/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/\[PROXY_PORT\]/$PROXY_PORT/" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/@@@@VPN_PASS@@@@/$VPN_PASS/g" scripts/dockervpn > tmp && mv tmp scripts/dockervpn
-sed "s/@@@@PROXY_PASS@@@@/$PROXY_PASS/g" scripts/dockervpn > tmp && mv tmp scripts/dockervpn
-sed "s@\[VPN_ENDPOINT\]@$VPN_ENDPOINT@g" scripts/vpn.sh > tmp && mv tmp scripts/vpn.sh
+sed "s/\\[VPN_USER\\]/$VPN_USER/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/\\[VPN_PASS\\]/$VPN_PASS/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/\\[SECRET_KEY\\]/$SECRET_KEY/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/\\[PROXY_USER\\]/$PROXY_USER/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/\\[PROXY_PASS\\]/$PROXY_PASS/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/\\[PROXY_HOST\\]/$PROXY_HOST/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/\\[PROXY_PORT\\]/$PROXY_PORT/" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/@@@@VPN_PASS@@@@/$VPN_PASS/g" scripts/dockervpn >tmp && mv tmp scripts/dockervpn
+sed "s/@@@@PROXY_PASS@@@@/$PROXY_PASS/g" scripts/dockervpn >tmp && mv tmp scripts/dockervpn
+sed "s@\\[VPN_ENDPOINT\\]@$VPN_ENDPOINT@g" scripts/vpn.sh >tmp && mv tmp scripts/vpn.sh
 chmod +x scripts/dockervpn && chmod +x scripts/vpn.sh
 
 echo -e '\nThe following commands may require your password for sudo.\n'
 
 ./uninstall.sh
-sudo docker build -t vpn .
 
-if [[ $? -eq 0 ]]; then
-  mkdir -p "${HOME}/share"
-  echo -e '\nCopying easy startup scripts to /usr/local/bin...'
-  echo -e '\nThe following commands may require your password for sudo.\n'
-  sudo cp -v scripts/dockervpn /usr/local/bin/
-  sudo chmod +x /usr/local/bin/dockervpn
-  sudo cp -v scripts/sshvpn /usr/local/bin/
-  sudo chmod +x /usr/local/bin/sshvpn
+if sudo docker build -t vpn .; then
+	mkdir -p "${HOME}/share"
+	echo -e '\nCopying easy startup scripts to /usr/local/bin...'
+	echo -e '\nThe following commands may require your password for sudo.\n'
+	sudo cp -v scripts/dockervpn /usr/local/bin/
+	sudo chmod +x /usr/local/bin/dockervpn
+	sudo cp -v scripts/sshvpn /usr/local/bin/
+	sudo chmod +x /usr/local/bin/sshvpn
 fi
 
 # Sanitize Modified Installation Files:
-sed "s/VPN_USER=${VPN_USER}/VPN_USER=\[VPN_USER\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/VPN_PASS=${VPN_PASS}/VPN_PASS=\[VPN_PASS\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/SECRET_KEY=${SECRET_KEY}/SECRET_KEY=\[SECRET_KEY\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/PROXY_USER=${PROXY_USER}/PROXY_USER=\[PROXY_USER\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/PROXY_PASS=${PROXY_PASS}/PROXY_PASS=\[PROXY_PASS\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/PROXY_HOST=${PROXY_HOST}/PROXY_HOST=\[PROXY_HOST\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/PROXY_PORT=${PROXY_PORT}/PROXY_PORT=\[PROXY_PORT\]/g" Dockerfile > tmp && mv tmp Dockerfile
-sed "s/${VPN_PASS}/@@@@VPN_PASS@@@@/g" scripts/dockervpn > tmp && mv tmp scripts/dockervpn
-sed "s/${PROXY_PASS}/@@@@PROXY_PASS@@@@/g" scripts/dockervpn > tmp && mv tmp scripts/dockervpn
-sed "s@${VPN_ENDPOINT}@\[VPN_ENDPOINT\]@g" scripts/vpn.sh > tmp && mv tmp scripts/vpn.sh
+sed "s/VPN_USER=${VPN_USER}/VPN_USER=\\[VPN_USER\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/VPN_PASS=${VPN_PASS}/VPN_PASS=\\[VPN_PASS\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/SECRET_KEY=${SECRET_KEY}/SECRET_KEY=\\[SECRET_KEY\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/PROXY_USER=${PROXY_USER}/PROXY_USER=\\[PROXY_USER\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/PROXY_PASS=${PROXY_PASS}/PROXY_PASS=\\[PROXY_PASS\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/PROXY_HOST=${PROXY_HOST}/PROXY_HOST=\\[PROXY_HOST\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/PROXY_PORT=${PROXY_PORT}/PROXY_PORT=\\[PROXY_PORT\\]/g" Dockerfile >tmp && mv tmp Dockerfile
+sed "s/${VPN_PASS}/@@@@VPN_PASS@@@@/g" scripts/dockervpn >tmp && mv tmp scripts/dockervpn
+sed "s/${PROXY_PASS}/@@@@PROXY_PASS@@@@/g" scripts/dockervpn >tmp && mv tmp scripts/dockervpn
+sed "s@${VPN_ENDPOINT}@\\[VPN_ENDPOINT\\]@g" scripts/vpn.sh >tmp && mv tmp scripts/vpn.sh
 chmod +x scripts/dockervpn && chmod +x scripts/vpn.sh
 
 /usr/local/bin/dockervpn --help | head -9

--- a/scripts/dockervpn
+++ b/scripts/dockervpn
@@ -18,7 +18,7 @@
 ##############################################################################
 
 show_help() {
-echo -e "
+	echo -e "
 Connect:		'dockervpn'
 View status/logs:	'dockervpn --status'
 Re-connect:		'dockervpn'
@@ -49,114 +49,114 @@ To change (and persist) VPN and/or proxy passwords:
 }
 
 change_vpn_pass() {
-  if [[ (-n $2) && (-n $3)  && (-n $4) && (-n $5) ]]; then
-    OLD_VPN_PASS="$2"
-    NEW_VPN_PASS="$3"
-    OLD_PROXY_PASS="$4"
-    NEW_PROXY_PASS="$5"
-  elif [[ (-n $2) && (-n $3) && (-z $4) && (-z $5) ]]; then
-    OLD_VPN_PASS="$2"
-    NEW_VPN_PASS="$3"
-    OLD_PROXY_PASS="$2"
-    NEW_PROXY_PASS="$3"
-  else
-    read -p 'Enter your old VPN password: ' OLD_VPN_PASS
-    read -p 'Enter your new VPN password: ' NEWP_VPN_PASS
-    read -p 'Enter your old PROXY password: ' OLD_PROXY_PASS
-    read -p 'Enter your new VPN password: ' NEW_PROXY_PASS
-  fi
-  if [[ -z $(grep "$OLD_VPN_PASS" /usr/local/bin/dockervpn) ]]; then
-    echo -e '\n[ERROR]  Please check your current password in /usr/local/bin/dockervpn.'
-    exit
-  fi
-  TMP="$(mktemp)"
-  sudo sed "s/$OLD_VPN_PASS/$NEW_VPN_PASS/g" /usr/local/bin/dockervpn > "$TMP" &&\
-  sudo mv -v "$TMP" /usr/local/bin/dockervpn &&\
-  TMP="$(mktemp)" &&\
-  sudo sed "s/$OLD_PROXY_PASS/$NEW_PROXY_PASS/g" /usr/local/bin/dockervpn > "$TMP" &&\
-  sudo mv -v "$TMP" /usr/local/bin/dockervpn
-  sudo chmod +x /usr/local/bin/dockervpn
-  if [[ -n $(grep "$NEW_VPN_PASS" /usr/local/bin/dockervpn) ]]; then
-    echo -e '\n[SUCCESS]  Your DockerVPN password(s) were changed successfully.'
-  else
-    echo -e '\n[ERROR]  Please double-check your passwords in /usr/local/bin/dockervpn.\n'
-    exit
-  fi
+	if [[ (-n $2) && (-n $3) && (-n $4) && (-n $5) ]]; then
+		OLD_VPN_PASS="$2"
+		NEW_VPN_PASS="$3"
+		OLD_PROXY_PASS="$4"
+		NEW_PROXY_PASS="$5"
+	elif [[ (-n $2) && (-n $3) && (-z $4) && (-z $5) ]]; then
+		OLD_VPN_PASS="$2"
+		NEW_VPN_PASS="$3"
+		OLD_PROXY_PASS="$2"
+		NEW_PROXY_PASS="$3"
+	else
+		read -rp 'Enter your old VPN password: ' OLD_VPN_PASS
+		read -rp 'Enter your new VPN password: ' NEW_VPN_PASS
+		read -rp 'Enter your old PROXY password: ' OLD_PROXY_PASS
+		read -rp 'Enter your new VPN password: ' NEW_PROXY_PASS
+	fi
+	if ! grep -q "$OLD_VPN_PASS" /usr/local/bin/dockervpn; then
+		echo -e '\n[ERROR]  Please check your current password in /usr/local/bin/dockervpn.'
+		exit
+	fi
+	TMP="$(mktemp)"
+	sed "s/$OLD_VPN_PASS/$NEW_VPN_PASS/g" /usr/local/bin/dockervpn | sudo tee "$TMP" &&
+		sudo mv -v "$TMP" /usr/local/bin/dockervpn &&
+		TMP="$(mktemp)" &&
+		sed "s/$OLD_PROXY_PASS/$NEW_PROXY_PASS/g" /usr/local/bin/dockervpn | sudo tee "$TMP" &&
+		sudo mv -v "$TMP" /usr/local/bin/dockervpn
+	sudo chmod +x /usr/local/bin/dockervpn
+	if grep -q "$NEW_VPN_PASS" /usr/local/bin/dockervpn; then
+		echo -e '\n[SUCCESS]  Your DockerVPN password(s) were changed successfully.'
+	else
+		echo -e '\n[ERROR]  Please double-check your passwords in /usr/local/bin/dockervpn.\n'
+		exit
+	fi
 }
 
 pre_start() {
-  docker stop vpn > /dev/null 2>&1
-  docker rm vpn > /dev/null 2>&1
+	docker stop vpn >/dev/null 2>&1
+	docker rm vpn >/dev/null 2>&1
 }
 
 post_start() {
 	sleep 2
-	if $(docker inspect -f '{{.State.Running}}' vpn); then
-                t='\t'
+	if docker inspect -f '{{.State.Running}}' vpn; then
+		t='\t'
 		uname -a | grep Linux >/dev/null && show_help | head -9 | sed -r "s/Connect:.*/VPN STATUS:${t}${t}running/"
 		uname -a | grep Darwin >/dev/null && show_help | head -9 | sed -E "s/Connect:.*/VPN STATUS:${t}${t}running/"
 	else
-		echo -e "\n[ERROR]  Failed to start:\n"
+		echo -e "\\n[ERROR]  Failed to start:\\n"
 		docker logs vpn
 	fi
 }
 
 normal_start() {
-  pre_start
-  docker run --privileged -v $HOME/share:/mnt/host -dp 8888:8888 -e "VPN_PASS=@@@@VPN_PASS@@@@" -e "PROXY_PASS=@@@@VPN_PASS@@@@" --name vpn vpn
-  post_start
+	pre_start
+	docker run --privileged -v "$HOME/share:/mnt/host" -dp 8888:8888 -e "VPN_PASS=@@@@VPN_PASS@@@@" -e "PROXY_PASS=@@@@VPN_PASS@@@@" --name vpn vpn
+	post_start
 }
 
 interactive_start() {
-  pre_start
-  docker run --privileged -v $HOME/share:/mnt/host -dp 8888:8888 -e "VPN_USER=$VPN_USER" -e "VPN_PASS=$VPN_PASS" -e "PROXY_USER=$VPN_USER" -e "PROXY_PASS=$VPN_PASS" --name vpn vpn
-  post_start
+	pre_start
+	docker run --privileged -v "$HOME/share:/mnt/host" -dp 8888:8888 -e "VPN_USER=$VPN_USER" -e "VPN_PASS=$VPN_PASS" -e "PROXY_USER=$PROXY_USER" -e "PROXY_PASS=$PROXY_PASS" --name vpn vpn
+	post_start
 }
 
 alt_endpoint_start() {
-  pre_start
-  docker run --privileged -v $HOME/share:/mnt/host -dp 8888:8888 -e "VPN_USER=$VPN_USER" -e "VPN_PASS=$VPN_PASS" -e "PROXY_USER=$VPN_USER" -e "PROXY_PASS=$VPN_PASS" -e "VPN_ENDPOINT=$VPN_ENDPOINT" --name vpn vpn
-  post_start
+	pre_start
+	docker run --privileged -v "$HOME/share:/mnt/host" -dp 8888:8888 -e "VPN_USER=$VPN_USER" -e "VPN_PASS=$VPN_PASS" -e "PROXY_USER=$VPN_USER" -e "PROXY_PASS=$VPN_PASS" -e "VPN_ENDPOINT=$VPN_ENDPOINT" --name vpn vpn
+	post_start
 }
 
 #### START:
 
-if [[ -n $(echo "${@}" | grep -E '(-h)|(help)') ]]; then
-  show_help
-  exit
-elif [[ -n $(echo "${@}" | grep changepass) ]]; then
-  change_vpn_pass "${@}"
-  exit
+if echo "${@}" | grep -qE '(-h)|(help)'; then
+	show_help
+	exit
+elif echo "${@}" | grep -q changepass; then
+	change_vpn_pass "${@}"
+	exit
 elif [[ ($1 = -i) || ($1 = --interactive) ]]; then
-  read -p 'VPN Username: ' VPN_USER
-  read -p 'VPN Password: ' VPN_PASS
-  read -p 'Proxy Username: ' PROXY_USER
-  read -p 'Proxy Password: ' PROXY_PASS
-  interactive_start
-  exit
-elif [[ (-n $(echo "${@}" | grep '\-u')) || (-n $(echo "${@}" | grep '\-\-user')) ]]; then
-  if [[ ($3 = -p) || ($3 = --password) ]]; then
-    VPN_USER="$2"
-    VPN_PASS="$3"
-    PROXY_USER="$2"
-    PROXY_PASS="$3"
-    interactive_start
-    exit
-  else
-    VPN_USER="$2"
-    PROXY_USER="$2"
-    read -p 'Password: ' VPN_PASS
-    PROXY_PASS="$VPN_PASS"
-    interactive_start
-    exit
-  fi
+	read -rp 'VPN Username: ' VPN_USER
+	read -rp 'VPN Password: ' VPN_PASS
+	read -rp 'Proxy Username: ' PROXY_USER
+	read -rp 'Proxy Password: ' PROXY_PASS
+	interactive_start
+	exit
+elif echo "${@}" | grep -q '\-u' || echo "${@}" | grep -q '\-\-user'; then
+	if [[ ($3 = -p) || ($3 = --password) ]]; then
+		VPN_USER="$2"
+		VPN_PASS="$3"
+		PROXY_USER="$2"
+		PROXY_PASS="$3"
+		interactive_start
+		exit
+	else
+		VPN_USER="$2"
+		PROXY_USER="$2"
+		read -rp 'Password: ' VPN_PASS
+		PROXY_PASS="$VPN_PASS"
+		interactive_start
+		exit
+	fi
 elif [[ ($1 = -c) || ($1 = --creds) ]]; then
-  VPN_USER="$(echo "$2" | cut -d ':' -f1)"
-  VPN_PASS="$(echo "$2" | cut -d ':' -f2)"
-  interactive_start
-  exit
+	VPN_USER="$(echo "$2" | cut -d ':' -f1)"
+	VPN_PASS="$(echo "$2" | cut -d ':' -f2)"
+	interactive_start
+	exit
 elif [[ ($1 = -s) || ($1 = --status) ]]; then
-  docker logs vpn
+	docker logs vpn
 else
-  normal_start
+	normal_start
 fi


### PR DESCRIPTION
Ran shellcheck and fixed the warnings that were detected. Hopefully this
will fix the issue we were having with the POST that was being made.

Warnings:
- SC2161: read without -r will mangle backslashes.
- SC1117: Backslash is literal in "\[". Prefer explicit escaping: "\\[".
- SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
- SC2024: sudo doesn't affect redirects. Use ..| sudo tee file
- SC2086: Double quote to prevent globbing and word splitting.
- SC2143: Use grep -q instead of comparing output with [ -n .. ].
- SC2091: Remove surrounding $() to avoid executing output.
- SC2034: PROXY_USER appears unused. Verify use (or export if used externally).

https://github.com/koalaman/shellcheck/wiki

Unfortunately, shfmt ran on save, if this is a problem then I can redo the PR.